### PR TITLE
Prevent errors if editor is not set

### DIFF
--- a/lib/byebug-breakpoints.coffee
+++ b/lib/byebug-breakpoints.coffee
@@ -351,6 +351,8 @@ module.exports = ByebugBreakpoints =
   getCachedDecorations: (editor) ->
     # console.log "getCachedDecorations"
     # console.log @decorationsByEditorId[editor.id]
+    return unless editor
+    
     @decorationsByEditorId[editor.id]
 
   setCachedDecoration: (editor, type, decoration, line) ->


### PR DESCRIPTION
Fix for error:
TypeError: Cannot read property 'id' of undefined
    at Object.getCachedDecorations (/home/phil/.atom/packages/byebug-breakpoints/lib/byebug-breakpoints.coffee:354:35)
    at /home/phil/.atom/packages/byebug-breakpoints/lib/byebug-breakpoints.coffee:239:15
    at FSReqWrap.readFileAfterClose [as oncomplete] (internal/fs/read_file_context.js:53:3)